### PR TITLE
Removing magic methods in Diaporama Actions

### DIFF
--- a/Action/DiaporamaAction.php
+++ b/Action/DiaporamaAction.php
@@ -15,6 +15,7 @@ namespace Diaporamas\Action;
 use Diaporamas\Action\Base\DiaporamaAction as  BaseDiaporamaAction;
 use Diaporamas\Event\DiaporamaEvent;
 use Diaporamas\Event\DiaporamaEvents;
+use Diaporamas\Event\DiaporamaHtmlEvent;
 use Diaporamas\Model\Diaporama;
 use Thelia\Core\Template\ParserInterface;
 use Thelia\Core\Template\TemplateHelper;
@@ -68,15 +69,10 @@ class DiaporamaAction extends BaseDiaporamaAction
      * Get Diaporama HTML code to put in a page.
      * @param DiaporamaEvent $event
      */
-    public function getDiaporamaDescription(DiaporamaEvent $event)
+    public function getDiaporamaDescription(DiaporamaHtmlEvent $event)
     {
-        $event->__set(
-            'diaporama_html',
-            $this->getShortcodeHTML(
-                $event->getShortcode(),
-                $event->__get('image_width'),
-                $event->__get('image_height')
-            )
+        $event->setDiaporamaHtml(
+            $this->getShortcodeHTML($event->getShortcode(), $event->getImageWidth(), $event->getImageHeight())
         );
     }
 
@@ -84,9 +80,9 @@ class DiaporamaAction extends BaseDiaporamaAction
      * Parsing a description, in order to replace shortcodes with their HTML codes
      * @param DiaporamaEvent $event
      */
-    public function parseDiaporamaDescription(DiaporamaEvent $event)
+    public function parseDiaporamaDescription(DiaporamaHtmlEvent $event)
     {
-        $event->__set('entity_description', $this->updateDescription($event->__get('entity_description')));
+        $event->setEntityDescription($this->updateDescription($event->getEntityDescription()));
     }
 
     /**

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>0.1</version>
+    <version>0.1.3</version>
     <author>
         <name>Romain Ducher</name>
         <email>rducher@openstudio.fr</email>

--- a/Controller/DiaporamaController.php
+++ b/Controller/DiaporamaController.php
@@ -16,6 +16,7 @@ use Diaporamas\Controller\Base\DiaporamaController as BaseDiaporamaController;
 use Diaporamas\Diaporamas;
 use Diaporamas\Event\DiaporamaEvent;
 use Diaporamas\Event\DiaporamaEvents;
+use Diaporamas\Event\DiaporamaHtmlEvent;
 use Diaporamas\Loop\DiaporamaImage as DiaporamaImageLoop;
 use Diaporamas\Model\Diaporama;
 use Diaporamas\Model\DiaporamaImage;
@@ -60,20 +61,21 @@ class DiaporamaController extends BaseDiaporamaController
     {
         $width = $this->getRequest()->query->get('width');
         $height = $this->getRequest()->query->get('height');
-        $event = new DiaporamaEvent();
-        $event->__set('image_width', $width);
-        $event->__set('image_height', $height);
+        $event = new DiaporamaHtmlEvent();
+        $event->setShortcode($shortcode);
+        $event->setImageWidth($width);
+        $event->setImageHeight($height);
         $this->dispatch(DiaporamaEvents::DIAPORAMA_HTML, $event);
-        return new Response($event->__get('diaporama_html'));
+        return new Response($event->getDiaporamaHtml());
     }
 
     public function replaceShortcodesAction()
     {
         $description = $this->getRequest()->request->get('description');
-        $event = new DiaporamaEvent();
-        $event->__set('entity_description', $description);
+        $event = new DiaporamaHtmlEvent();
+        $event->setEntityDescription($description);
         $this->dispatch(DiaporamaEvents::DIAPORAMA_PARSE, $event);
-        return new Response($event->__get('entity_description'));
+        return new Response($event->getEntityDescription());
     }
 
     public function getDiaporamaDataAction($shortcode)

--- a/Controller/DiaporamaFrontController.php
+++ b/Controller/DiaporamaFrontController.php
@@ -13,30 +13,32 @@
 
 namespace Diaporamas\Controller;
 
-use Diaporamas\Event\DiaporamaEvent;
 use Diaporamas\Event\DiaporamaEvents;
+use Diaporamas\Event\DiaporamaHtmlEvent;
 use Thelia\Controller\Front\BaseFrontController;
 use Thelia\Core\HttpFoundation\Response;
 
 class DiaporamaFrontController extends BaseFrontController
 {
+
     public function getDiaporamaHtmlAction($shortcode)
     {
         $width = $this->getRequest()->query->get('width');
         $height = $this->getRequest()->query->get('height');
-        $event = new DiaporamaEvent();
-        $event->__set('image_width', $width);
-        $event->__set('image_height', $height);
+        $event = new DiaporamaHtmlEvent();
+        $event->setShortcode($shortcode);
+        $event->setImageWidth($width);
+        $event->setImageHeight($height);
         $this->dispatch(DiaporamaEvents::DIAPORAMA_HTML_FRONT, $event);
-        return new Response($event->__get('diaporama_html'));
+        return new Response($event->getDiaporamaHtml());
     }
 
     public function replaceShortcodesAction()
     {
         $description = $this->getRequest()->request->get('description');
-        $event = new DiaporamaEvent();
-        $event->__set('entity_description', $description);
+        $event = new DiaporamaHtmlEvent();
+        $event->setEntityDescription($description);
         $this->dispatch(DiaporamaEvents::DIAPORAMA_PARSE_FRONT, $event);
-        return new Response($event->__get('entity_description'));
+        return new Response($event->getEntityDescription());
     }
 }

--- a/Event/DiaporamaHtmlEvent.php
+++ b/Event/DiaporamaHtmlEvent.php
@@ -19,31 +19,31 @@ namespace Diaporamas\Event;
 class DiaporamaHtmlEvent extends DiaporamaEvent
 {
     /** @var string */
-    protected $entity_description = null;
+    protected $entityDescription = null;
 
     /** @var int */
-    protected $image_width = null;
+    protected $imageWidth = null;
 
     /** @var int */
-    protected $image_height = null;
+    protected $imageHeight = null;
 
     /** @var string */
-    protected $diaporama_html = null;
+    protected $diaporamaHtml = null;
 
     /**
      * @return string
      */
     public function getEntityDescription()
     {
-        return $this->entity_description;
+        return $this->entityDescription;
     }
 
     /**
-     * @param string $entity_description
+     * @param string $entityDescription
      */
-    public function setEntityDescription($entity_description)
+    public function setEntityDescription($entityDescription)
     {
-        $this->entity_description = $entity_description;
+        $this->entityDescription = $entityDescription;
     }
 
     /**
@@ -51,15 +51,15 @@ class DiaporamaHtmlEvent extends DiaporamaEvent
      */
     public function getImageWidth()
     {
-        return $this->image_width;
+        return $this->imageWidth;
     }
 
     /**
-     * @param int $image_width
+     * @param int $imageWidth
      */
-    public function setImageWidth($image_width)
+    public function setImageWidth($imageWidth)
     {
-        $this->image_width = $image_width;
+        $this->imageWidth = $imageWidth;
     }
 
     /**
@@ -67,15 +67,15 @@ class DiaporamaHtmlEvent extends DiaporamaEvent
      */
     public function getImageHeight()
     {
-        return $this->image_height;
+        return $this->imageHeight;
     }
 
     /**
-     * @param int $image_height
+     * @param int $imageHeight
      */
-    public function setImageHeight($image_height)
+    public function setImageHeight($imageHeight)
     {
-        $this->image_height = $image_height;
+        $this->imageHeight = $imageHeight;
     }
 
     /**
@@ -83,14 +83,14 @@ class DiaporamaHtmlEvent extends DiaporamaEvent
      */
     public function getDiaporamaHtml()
     {
-        return $this->diaporama_html;
+        return $this->diaporamaHtml;
     }
 
     /**
-     * @param string $diaporama_html
+     * @param string $diaporamaHtml
      */
-    public function setDiaporamaHtml($diaporama_html)
+    public function setDiaporamaHtml($diaporamaHtml)
     {
-        $this->diaporama_html = $diaporama_html;
+        $this->diaporamaHtml = $diaporamaHtml;
     }
 }

--- a/Event/DiaporamaHtmlEvent.php
+++ b/Event/DiaporamaHtmlEvent.php
@@ -1,0 +1,96 @@
+<?php
+/*************************************************************************************/
+/*      This file is part of the "Diaporamas" Thelia 2 module.                       */
+/*                                                                                   */
+/*      Copyright (c) OpenStudio                                                     */
+/*      email : dev@thelia.net                                                       */
+/*      web : http://www.thelia.net                                                  */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE.txt  */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+namespace Diaporamas\Event;
+
+/**
+ * DiaporamaEvent extension for retrieving Diaporama HTML code.
+ * @package Diaporamas\Event
+ */
+class DiaporamaHtmlEvent extends DiaporamaEvent
+{
+    /** @var string */
+    protected $entity_description = null;
+
+    /** @var int */
+    protected $image_width = null;
+
+    /** @var int */
+    protected $image_height = null;
+
+    /** @var string */
+    protected $diaporama_html = null;
+
+    /**
+     * @return string
+     */
+    public function getEntityDescription()
+    {
+        return $this->entity_description;
+    }
+
+    /**
+     * @param string $entity_description
+     */
+    public function setEntityDescription($entity_description)
+    {
+        $this->entity_description = $entity_description;
+    }
+
+    /**
+     * @return int
+     */
+    public function getImageWidth()
+    {
+        return $this->image_width;
+    }
+
+    /**
+     * @param int $image_width
+     */
+    public function setImageWidth($image_width)
+    {
+        $this->image_width = $image_width;
+    }
+
+    /**
+     * @return int
+     */
+    public function getImageHeight()
+    {
+        return $this->image_height;
+    }
+
+    /**
+     * @param int $image_height
+     */
+    public function setImageHeight($image_height)
+    {
+        $this->image_height = $image_height;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDiaporamaHtml()
+    {
+        return $this->diaporama_html;
+    }
+
+    /**
+     * @param string $diaporama_html
+     */
+    public function setDiaporamaHtml($diaporama_html)
+    {
+        $this->diaporama_html = $diaporama_html;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ information about them.
 | `DiaporamaEvents::CREATE` | `DiaporamaEvent` | Creating a diaporama |
 | `DiaporamaEvents::UPDATE` | `DiaporamaEvent` | Updating a diaporama |
 | `DiaporamaEvents::DELETE` | `DiaporamaEvent` | Deleting a diaporama |
-| `DiaporamaEvents::DIAPORAMA_HTML` | `DiaporamaEvent` | While retrieving diaporama's HTML in the back office |
-| `DiaporamaEvents::DIAPORAMA_PARSE` | `DiaporamaEvent` | While parsing descriptions to insert diaporama's HTML in the back office |
-| `DiaporamaEvents::DIAPORAMA_HTML_FRONT` | `DiaporamaEvent` | Same as `DiaporamaEvents::DIAPORAMA_HTML` but for front office |
-| `DiaporamaEvents::DIAPORAMA_PARSE_FRONT` | `DiaporamaEvent` | Same as `DiaporamaEvents::DIAPORAMA_PARSE` but for front office |
+| `DiaporamaEvents::DIAPORAMA_HTML` | `DiaporamaHtmlEvent` | While retrieving diaporama's HTML in the back office |
+| `DiaporamaEvents::DIAPORAMA_PARSE` | `DiaporamaHtmlEvent` | While parsing descriptions to insert diaporama's HTML in the back office |
+| `DiaporamaEvents::DIAPORAMA_HTML_FRONT` | `DiaporamaHtmlEvent` | Same as `DiaporamaEvents::DIAPORAMA_HTML` but for front office |
+| `DiaporamaEvents::DIAPORAMA_PARSE_FRONT` | `DiaporamaHtmlEvent` | Same as `DiaporamaEvents::DIAPORAMA_PARSE` but for front office |
 | `DiaporamaImageEvents::CREATE` | `DiaporamaImageEvent` | Creating a diaporama image |
 | `DiaporamaImageEvents::UPDATE` | `DiaporamaImageEvent` | Updating a diaporama image |
 | `DiaporamaImageEvents::DELETE` | `DiaporamaImageEvent` | Deleting a diaporama image |


### PR DESCRIPTION
- Removing magic methods in Diaporama Actions
- Version bump in module.xml. It was still written "0.1" but the version is now "0.1.3".
